### PR TITLE
Spike/run tests in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:bionic-20200219
+
+SHELL [ "/bin/bash", "-c" ]
+
+USER  root
+
+RUN   set -e ; \
+      apt-get update -qq && \
+      apt-get install -qq -y \
+          firefox \
+          build-essential \
+          patch \
+          ruby-dev \
+          zlib1g-dev \
+          liblzma-dev \
+          openjdk-8-jdk-headless \
+          wget \
+          curl 
+          
+RUN gem install bundler
+
+ENV   APP /app
+
+RUN   adduser --home $APP --shell /bin/bash --gecos "" --disabled-password tester
+
+ADD   --chown=tester:tester ./Gemfile      \
+                            ./Rakefile     \
+                                              $APP/
+
+WORKDIR $APP
+                                              
+RUN   bundle install --quiet       
+
+USER tester
+
+ENTRYPOINT [ "/bin/bash" ]
+      
+CMD [ ]
+      
+
+      

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic-20200219
+FROM ubuntu:20.04
 
 SHELL [ "/bin/bash", "-c" ]
 
@@ -6,7 +6,7 @@ USER  root
 
 RUN   set -e ; \
       apt-get update -qq && \
-      apt-get install -qq -y \
+      DEBIAN_FRONTEND="noninteractive" TZ="europe/london" apt-get install -qq -y \
           firefox \
           build-essential \
           patch \
@@ -25,7 +25,7 @@ RUN   adduser --home $APP --shell /bin/bash --gecos "" --disabled-password teste
 
 ADD   --chown=tester:tester ./Gemfile      \
                             ./Rakefile     \
-                                              $APP/
+                            $APP/
 
 WORKDIR $APP
                                               

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,18 @@ SHELL [ "/bin/bash", "-c" ]
 
 USER  root
 
-RUN   set -e ; \
-      apt-get update -qq && \
-      DEBIAN_FRONTEND="noninteractive" TZ="europe/london" apt-get install -qq -y \
+RUN   apt-get update -qq
+
+RUN   DEBIAN_FRONTEND="noninteractive" TZ="europe/london" apt-get install -qq -y \
           firefox \
           build-essential \
           patch \
           ruby-dev \
           zlib1g-dev \
           liblzma-dev \
-          openjdk-8-jdk-headless \
           wget \
-          curl 
+          curl \
+          gosu
           
 RUN gem install bundler
 
@@ -29,13 +29,10 @@ ADD   --chown=tester:tester ./Gemfile      \
 
 WORKDIR $APP
                                               
-RUN   bundle install --quiet       
+RUN     bundle install --quiet
 
-USER tester
+COPY    docker/entrypoint /entrypoint
 
-ENTRYPOINT [ "/bin/bash" ]
+ENTRYPOINT [ "/entrypoint" ]
       
-CMD [ ]
-      
-
-      
+CMD [ "bin/test" ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: test-image release-test-image install-test-image test-dev test-preprod test-production test-server
+
+include bin/dkr-config
+
+export AWS_PROFILE = lr
+SHELL=/bin/bash
+
+test-image:
+	@docker build -t ${TEST_CONTAINER_NAME}:${TEST_CONTAINER_VERSION} .
+
+release-test-image:
+	@docker tag ${TEST_CONTAINER_NAME}:${TEST_CONTAINER_VERSION} ${REGISTRY}/${TEST_CONTAINER_NAME}:${TEST_CONTAINER_VERSION}
+	@docker push ${REGISTRY}/${TEST_CONTAINER_NAME}:${TEST_CONTAINER_VERSION}
+
+install-test-image:
+	@docker pull ${REGISTRY}/${TEST_CONTAINER_NAME}:${TEST_CONTAINER_VERSION}
+	@docker tag ${REGISTRY}/${TEST_CONTAINER_NAME}:${TEST_CONTAINER_VERSION} ${TEST_CONTAINER_NAME}:${TEST_CONTAINER_VERSION}
+
+test-dev:
+	TEST_URL=https://lr-ppd-dev-pres.epimorphics.net TEST_LB=true bin/dkr-test
+
+test-preprod:
+	bin/dkr-test-preprod
+
+test-production:
+	TEST_URL=https://landregistry.data.gov.uk TEST_LB=true bin/dkr-test
+	
+test-server:
+	TEST_URL=$(TEST_URL) bin/dkr-test 

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ install-test-image:
 	@docker tag ${REGISTRY}/${TEST_CONTAINER_NAME}:${TEST_CONTAINER_VERSION} ${TEST_CONTAINER_NAME}:${TEST_CONTAINER_VERSION}
 
 test-dev:
-	TEST_URL=https://lr-ppd-dev-pres.epimorphics.net TEST_LB=true bin/dkr-test
+	TEST_URL=https://lr-ppd-dev-pres.epimorphics.net TEST_LB=1 bin/dkr-test
 
 test-preprod:
 	bin/dkr-test-preprod
 
 test-production:
-	TEST_URL=https://landregistry.data.gov.uk TEST_LB=true bin/dkr-test
+	TEST_URL=https://landregistry.data.gov.uk TEST_LB=1 bin/dkr-test
 	
 test-server:
 	TEST_URL=$(TEST_URL) bin/dkr-test 

--- a/bin/dkr-config
+++ b/bin/dkr-config
@@ -2,6 +2,6 @@
 
 REGISTRY=018852084843.dkr.ecr.eu-west-1.amazonaws.com
 TEST_CONTAINER_NAME=epimorphics/lr-integration-test-container
-TEST_CONTAINER_VERSION=0.0.1-SNAPSHOT
+TEST_CONTAINER_VERSION=0.0.2-SNAPSHOT
 APP=/app
 

--- a/bin/dkr-config
+++ b/bin/dkr-config
@@ -1,0 +1,7 @@
+# specify common container parameters
+
+REGISTRY=018852084843.dkr.ecr.eu-west-1.amazonaws.com
+TEST_CONTAINER_NAME=epimorphics/lr-integration-test-container
+TEST_CONTAINER_VERSION=0.0.1-SNAPSHOT
+APP=/app
+

--- a/bin/dkr-test
+++ b/bin/dkr-test
@@ -31,49 +31,6 @@ HOST_IP=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
 
 TEST_CMD="${TEST_CMD:-bash bin/test} "
 
-# Sometimes we want to make the test browser window visible
-# which essential means giving the container access to an X windows server.
-# I have not yet found a satisfactory way of doing this.
-
-# The current approach depends on on whether the DISPLAY environment variable
-# identifies a socket or a domain.  If the value of the DISPLAY variable 
-# begins with a "/" or a ":", i.e. it identifies a socket, the 
-# display variable passed to the container points to the matching display 
-# on the IP address of the container host.  Otherwise the DISPLAY variable 
-# is passed to the container unmodified.
-#
-# To make this work, the container is run using the host network and xhost is
-# run to enable and then disable access to the X server from the host's IP address
-# before and after the container run.  
-#
-# This is unsatisfactory if the user want xhost enabled for the host's IP address anyway.
-# There must be a better way.
-
-function computeDisplayArg() {
-
-  if [ -n "$TEST_BROWSER_VISIBLE" ]
-  then
-    if [[ $DISPLAY = [/:]* ]]
-    then
-    
-      OIFS=$IFS
-      IFS=':' read -ra parts <<< "$DISPLAY"
-      d=${parts[1]}
-      DKR_DISPLAY="$HOST_IP:$d"
-      IFS=$OIFS
-      XHOST_ON_OFF=1
-    else
-      DKR_DISPLAY=$DISPLAY
-      XHOST_ON_OFF=0
-    fi
-    DISPLAY_ARG="-e DISPLAY=$DKR_DISPLAY"
-  else
-    DISPLAY_ARG=""
-  fi
-  
- }
-
-computeDisplayArg
 
 docker_cmd=" \
   docker run -it --rm \
@@ -84,9 +41,7 @@ docker_cmd=" \
   --volume=\"$PWD/specs:$APP/specs:ro\" \
   --volume=\"$PWD/bin:/$APP/bin:ro\" \
   --volume=\"$PWD/lib:$APP/lib:ro\" \
-  --volume=/private/tmp/.X11-unix:/tmp.X11-unix \
   --add-host "lr-pres-tunnel.epimorphics.net:$HOST_IP" \
-  $DISPLAY_ARG \
   -e IN_CONTAINER=1 \
   -e HOST_IP=\"$HOST_IP\" \
   -e TEST_BROWSER_VISIBLE=\"$TEST_BROWSER_VISIBLE\" \
@@ -102,7 +57,6 @@ docker_cmd=" \
   fi
   
   docker_cmd="$docker_cmd \
-  --network host \
   \"${TEST_CONTAINER_NAME}:${TEST_CONTAINER_VERSION}\" -c \"$TEST_CMD"
   
 # now append the arguments passed to this script
@@ -123,17 +77,6 @@ then
   echo "$docker_cmd"
 fi
 
-if [[ XHOST_ON_OFF = 1 ]]
-then
-  xhost +$HOST_IP
-fi
-
 eval "$docker_cmd"
-
-if [[ XHOST_ON_OFF = 1 ]]
-then 
-  xhost -$HOST_IP
-fi
-
 
 echo "test run complete"

--- a/bin/dkr-test
+++ b/bin/dkr-test
@@ -5,15 +5,6 @@
 
 set -e
 
-function cleanup() {
-  if [[ $HOST_ON_OFF = 1 ]]
-  then 
-    xhost -$HOST_IP
-  fi
-}
-
-trap cleanup EXIT
-
 SCRIPT_DIR=$( dirname "$0" )
 source "$SCRIPT_DIR/dkr-config"
 
@@ -29,7 +20,7 @@ HOST_IP=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
   
 # build the docker command to run the tests in the container
 
-TEST_CMD="${TEST_CMD:-bash bin/test} "
+TEST_CMD="${TEST_CMD:-bin/test} "
 
 
 docker_cmd=" \
@@ -41,9 +32,7 @@ docker_cmd=" \
   --volume=\"$PWD/specs:$APP/specs:ro\" \
   --volume=\"$PWD/bin:/$APP/bin:ro\" \
   --volume=\"$PWD/lib:$APP/lib:ro\" \
-  --add-host "lr-pres-tunnel.epimorphics.net:$HOST_IP" \
   -e IN_CONTAINER=1 \
-  -e HOST_IP=\"$HOST_IP\" \
   -e TEST_BROWSER_VISIBLE=\"$TEST_BROWSER_VISIBLE\" \
   -e TEST_URL=\"$TEST_URL\" \
   -e TEST_HOST=\"$TEST_HOST\" \
@@ -57,7 +46,7 @@ docker_cmd=" \
   fi
   
   docker_cmd="$docker_cmd \
-  \"${TEST_CONTAINER_NAME}:${TEST_CONTAINER_VERSION}\" -c \"$TEST_CMD"
+  \"${TEST_CONTAINER_NAME}:${TEST_CONTAINER_VERSION}\" \"$TEST_CMD"
   
 # now append the arguments passed to this script
   

--- a/bin/dkr-test
+++ b/bin/dkr-test
@@ -15,9 +15,6 @@ then
   PROTO="$TEST_PROTO:"
 fi
 
-# this works on a linux or a mac: windows not yet supported
-HOST_IP=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
-  
 # build the docker command to run the tests in the container
 
 TEST_CMD="${TEST_CMD:-bin/test} "

--- a/bin/dkr-test
+++ b/bin/dkr-test
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+# script that runs on a host system to run tests in a container.
+#
+
+set -e
+
+function cleanup() {
+  if [[ $HOST_ON_OFF = 1 ]]
+  then 
+    xhost -$HOST_IP
+  fi
+}
+
+trap cleanup EXIT
+
+SCRIPT_DIR=$( dirname "$0" )
+source "$SCRIPT_DIR/dkr-config"
+
+# usually testing a specific server so use http by default
+TEST_PROTO=${TEST_PROTO:-http}
+if ! [[ "$PROTO" == *: ]]
+then
+  PROTO="$TEST_PROTO:"
+fi
+
+# this works on a linux or a mac: windows not yet supported
+HOST_IP=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
+  
+# build the docker command to run the tests in the container
+
+TEST_CMD="${TEST_CMD:-bash bin/test} "
+
+# Sometimes we want to make the test browser window visible
+# which essential means giving the container access to an X windows server.
+# I have not yet found a satisfactory way of doing this.
+
+# The current approach depends on on whether the DISPLAY environment variable
+# identifies a socket or a domain.  If the value of the DISPLAY variable 
+# begins with a "/" or a ":", i.e. it identifies a socket, the 
+# display variable passed to the container points to the matching display 
+# on the IP address of the container host.  Otherwise the DISPLAY variable 
+# is passed to the container unmodified.
+#
+# To make this work, the container is run using the host network and xhost is
+# run to enable and then disable access to the X server from the host's IP address
+# before and after the container run.  
+#
+# This is unsatisfactory if the user want xhost enabled for the host's IP address anyway.
+# There must be a better way.
+
+function computeDisplayArg() {
+
+  if [ -n "$TEST_BROWSER_VISIBLE" ]
+  then
+    if [[ $DISPLAY = [/:]* ]]
+    then
+    
+      OIFS=$IFS
+      IFS=':' read -ra parts <<< "$DISPLAY"
+      d=${parts[1]}
+      DKR_DISPLAY="$HOST_IP:$d"
+      IFS=$OIFS
+      XHOST_ON_OFF=1
+    else
+      DKR_DISPLAY=$DISPLAY
+      XHOST_ON_OFF=0
+    fi
+    DISPLAY_ARG="-e DISPLAY=$DKR_DISPLAY"
+  else
+    DISPLAY_ARG=""
+  fi
+  
+ }
+
+computeDisplayArg
+
+docker_cmd=" \
+  docker run -it --rm \
+  --hostname=lr-integration-test \
+  --name=lr-integration-test \
+  --workdir=\"$APP\" \
+  --volume=\"$PWD/features:$APP/features:ro\" \
+  --volume=\"$PWD/specs:$APP/specs:ro\" \
+  --volume=\"$PWD/bin:/$APP/bin:ro\" \
+  --volume=\"$PWD/lib:$APP/lib:ro\" \
+  --volume=/private/tmp/.X11-unix:/tmp.X11-unix \
+  --add-host "lr-pres-tunnel.epimorphics.net:$HOST_IP" \
+  $DISPLAY_ARG \
+  -e IN_CONTAINER=1 \
+  -e HOST_IP=\"$HOST_IP\" \
+  -e TEST_BROWSER_VISIBLE=\"$TEST_BROWSER_VISIBLE\" \
+  -e TEST_URL=\"$TEST_URL\" \
+  -e TEST_HOST=\"$TEST_HOST\" \
+  -e TEST_PROTO=\"$TEST_PROTO\" \
+  -e TEST_LB=\"$TEST_LB\" \
+  -e IN_CI=\"$IN_CI\" "
+  
+  if ! [ -z ${RECENT+x} ];
+  then
+    docker_cmd="$docker_cmd -e RECENT=\"$RECENT\""
+  fi
+  
+  docker_cmd="$docker_cmd \
+  --network host \
+  \"${TEST_CONTAINER_NAME}:${TEST_CONTAINER_VERSION}\" -c \"$TEST_CMD"
+  
+# now append the arguments passed to this script
+  
+for p in "$@"
+do
+  docker_cmd="$docker_cmd \\\"$p\\\""
+done
+
+# and finally the closing quote
+
+docker_cmd="$docker_cmd\""
+
+# now show and execute it
+
+if [[ DEBUG = 1 ]]
+then
+  echo "$docker_cmd"
+fi
+
+if [[ XHOST_ON_OFF = 1 ]]
+then
+  xhost +$HOST_IP
+fi
+
+eval "$docker_cmd"
+
+if [[ XHOST_ON_OFF = 1 ]]
+then 
+  xhost -$HOST_IP
+fi
+
+
+echo "test run complete"

--- a/bin/dkr-test-preprod
+++ b/bin/dkr-test-preprod
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Run tests over ssh tunnel to an endpoint
+# Run tests over ssh tunnel to preprod
 #
 # $TEST_PORT optional (defaults to 8000) port number of local end of SSH tunnel
 # $TUNNEL_ENDPOINT optional (defaults to lr-ppd-preprod-pres-1)
@@ -8,9 +8,8 @@
 
 set -e
 
-
-HERE=`dirname $0`
-source "$HERE/lib"
+SCRIPT_DIR=`dirname $0`
+source "$SCRIPT_DIR/lib"
 
 trap closeSSHTunnel EXIT
 
@@ -19,9 +18,12 @@ export TEST_HOST="lr-pres-tunnel.epimorphics.net:$TEST_PORT"
 export TEST_USER=ubuntu
 export TUNNEL_ENDPOINT=${TUNNEL_ENDPOINT:-lr-ppd-preprod-pres-1}
 
-verify-etc-hosts
+# this works on a linux or a mac: windows not yet supported
+HOST_IP=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
 
-openSSHTunnel "$TUNNEL_ENDPOINT" localhost "$TEST_PORT" "$TEST_USER" "$SSH_CREDS"
+openSSHTunnel "$TUNNEL_ENDPOINT" "$HOST_IP" "$TEST_PORT" "$TEST_USER" "$SSH_CREDS"
 
-"$HERE/test"
+"$SCRIPT_DIR/dkr-test"
+
+closeSSHTunnel
 

--- a/bin/dkr-test-preprod
+++ b/bin/dkr-test-preprod
@@ -18,10 +18,7 @@ export TEST_HOST="lr-pres-tunnel.epimorphics.net:$TEST_PORT"
 export TEST_USER=ubuntu
 export TUNNEL_ENDPOINT=${TUNNEL_ENDPOINT:-lr-ppd-preprod-pres-1}
 
-# this works on a linux or a mac: windows not yet supported
-HOST_IP=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
-
-openSSHTunnel "$TUNNEL_ENDPOINT" "$HOST_IP" "$TEST_PORT" "$TEST_USER" "$SSH_CREDS"
+openSSHTunnel "$TUNNEL_ENDPOINT" "localhost" "$TEST_PORT" "$TEST_USER" "$SSH_CREDS"
 
 "$SCRIPT_DIR/dkr-test"
 

--- a/bin/lib
+++ b/bin/lib
@@ -1,0 +1,34 @@
+# common functions used by local scripts
+
+function verify-etc-hosts {
+  cat /etc/hosts | grep "^127.0.0.1" \
+  | grep -E '^127.0.0.1[[:space:]]+lr-pres-tunnel.epimorphics.net' /etc/hosts \
+  > /dev/null || ( echo "\"127.0.0.1 lr-pres-tunnel.epimorphics.net\" must be set in /etc/hosts" ; exit 1 )   
+}
+
+function openSSHTunnel {
+
+  local tunnel_endpoint="$1"
+  local local_host="$2"
+  local test_port="$3"
+  local test_user="$4"
+  local ssh_creds="$5"
+    
+    # this works on a linux or a mac: windows not yet supported
+  HOST_IP=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
+  
+  cmd="ssh "$ssh_creds" -fN -L $local_host:${test_port}:localhost:80 ${test_user}@$tunnel_endpoint"
+  eval "$cmd"
+  SSH_PID=$( pgrep -f "ssh.*-fN -L [^:]*:${test_port}:localhost:80" )
+  echo "created ssh tunnel $SSH_PID"
+  echo
+}
+
+function closeSSHTunnel {
+  if [ -n "$SSH_PID" ]
+  then
+    echo "closing SSH tunnel $SSH_PID"
+    kill "$SSH_PID"
+    echo
+  fi
+}

--- a/bin/lib
+++ b/bin/lib
@@ -13,10 +13,7 @@ function openSSHTunnel {
   local test_port="$3"
   local test_user="$4"
   local ssh_creds="$5"
-    
-    # this works on a linux or a mac: windows not yet supported
-  HOST_IP=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
-  
+     
   cmd="ssh "$ssh_creds" -fN -L $local_host:${test_port}:localhost:80 ${test_user}@$tunnel_endpoint"
   eval "$cmd"
   SSH_PID=$( pgrep -f "ssh.*-fN -L [^:]*:${test_port}:localhost:80" )

--- a/bin/test
+++ b/bin/test
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+if [ -n "$TEST_URL" ]
+then
+  export TEST_PROTO=$( echo "$TEST_URL" | sed -e 's/\([^:]*:\).*/\1/' )
+  export TEST_HOST=$( echo "$TEST_URL" | sed -e 's/[^:]*:\/\/\(.*\)/\1/' )
+fi
+
+
 PROTO=${TEST_PROTO:-http:}
 
 if ! [[ "$PROTO" == *: ]]
@@ -23,19 +30,19 @@ fi
 
 rm -rf test-output/*
 mkdir -p test-output
-wget -O test-output/test-query "$PROTO//$TEST_HOST/landregistry/query?query=SELECT * { ?s ?p ?o } LIMIT 1"
+wget -O /dev/null "$PROTO//$TEST_HOST/landregistry/query?query=SELECT * { ?s ?p ?o } LIMIT 1"
 die_on_failure 'Test query failed'
 
 bundle exec rake test
 die_on_failure 'Integration test suite failed'
 
-if [ "$TEST_LB" != "true" ]
+if [ "$TEST_LB" != "1" ]
 then
   echo "running mod_qos test"
 
   echo "NOTE: this test will not work through a load balancer as it relies on being able to set X-FORWARDED-FOR"
   echo
-  echo "To disable set environment variable TEST_LB=true"
+  echo "To disable set environment variable TEST_LB=1"
   echo
 
   SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# add lr-pres-tunnel.epimorphics.net to etc hosts
+HOST_IP=$( getent hosts host.docker.internal | awk '{ print $1 }' )
+echo "$HOST_IP lr-pres-tunnel.epimorphics.net" >> /etc/hosts
+
+# drop priviledges and run the tests as user 'tester'
+
+exec gosu tester $@

--- a/readme.md
+++ b/readme.md
@@ -28,17 +28,29 @@ There are two ways to run the tests, either in a docker container or natively.
 The docker container provides a stable software environment for running the tests.
 Running natively does not require docker to be installed.
 
-##  Running with Docker
+## Running with Docker
 
-### Setup
+### Docker Setup
 
 - Docker must be installed and the docker daemon running
-- the aws credentials helper should be installed and configured - 
-  see https://github.com/awslabs/amazon-ecr-credential-helper/blob/master/README.md
-  The AWS_PROFILE should be set - defaults to 'lr'
-- to download the container `make install-test-container`
+- either build your own test image with `make test-image`
+- or set up access to the LR container image registry (see below) and run
+  `make install-test-image` to install the container from the registry
+  
+To access the LR container image registry, AWS credentials need to be installed
+and configured.  Access the LR container image registry is needed to download
+a prebuilt container or to publish a new container to the registry.
 
-### Running the tests
+- create an AWS profile for an IAM user with access to the LR container registry
+- see [Amazon AWS credentials documentation](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_profiles.html)
+  - By default the scripts in this directory will use the profile name `lr`,
+but this can be changed to a name of your choice with
+`export AWS_PROFILE=<profile name>`
+- install the aws credentials helper - this will automatically log your docker
+daemon into the LR container registry - see [Amazon AWS credentials helper
+documentation](https://github.com/awslabs/amazon-ecr-credential-helper/blob/master/README.md)
+
+### Running the tests in a docker container
 
 Standard test configurations can be run using make:
 
@@ -48,11 +60,13 @@ Standard test configurations can be run using make:
 
 Alternatively the test scripts can be run directly, e.g.
 
-```
+```sh
     TEST_HOST=lr-ppd-dev-pres-1.epimorphics.net bin/dkr-test
 ```
+
 or
-```
+
+```sh
    TEST_URL=http://lr-ppd-dev-pres-1.epimorphics.net bin/dkr-test
 ```
 
@@ -62,12 +76,12 @@ to the tests and scripts will be executed by the container.
 
 To get an interactive bash shell in the docker container, e.g. for debugging:
 
-
-```
+```sh
     TEST_CMD="bash -" bin/dkr-test
 ```
 
-Other environment variables that control the execution of the tests are as described below.
+Other environment variables that control the execution of the tests are as
+described below.
 
 ## Running Natively
 
@@ -78,13 +92,13 @@ to manage local Ruby versions on developer machines.
 
 Run `bundle` in the root directory to install Rubygems dependencies.
 
-### Running the tests
+### Running the tests Natively
 
 Determine which server is going to be tested, e.g. `lr-ppd-dev-pres-1`, then
 
 invoke the tests:
 
-```
+```sh
     TEST_HOST=lr-ppd-dev-pres.epimorphics.net bin/test
 ```
 
@@ -98,7 +112,6 @@ The service to test can also be a load-balancer, but note that the mod-QoS tests
 do not work in this case. To use a load-balacer as the `TEST_HOST`, set the `TEST_LB`
 environment variable:
 
-
 ```sh
 TEST_LB=1 TEST_HOST=lr-ppd-dev-pres.epimorphics.net bin/test
 ```
@@ -111,20 +124,25 @@ By default, the tests will omit any tests dependent on there being recent data
 available to test against.  To **include** the recent tests in the test run, set the environment
 variable `RECENT` to any non-empty value:
 
+```sh
     RECENT=1 TEST_HOST=lr-ppd-dev-pres.epimorphics.net bin/test
-    
+```
+
 ### Tests that don't work a CI environment
 
 Most tests works in a CI environment, but standard reports tests do not.  To exclude
 these tests:
 
+```sh
     IN_CI=1 TEST_HOST=lr-ppd-dev-pres.epimorphics.net bin/test
+```
 
 ### Testing via a Load Balancer
 
 Some tests, such as the quality of service tests, do not work via a load balancer.
 To disable these tests set the `TEST_LB` environment variable to true:
-```
+
+```sh
    TEST_LB=true TEST_URL=https://landregistry.data.gov.uk bin/test
 ```
 
@@ -132,19 +150,19 @@ To disable these tests set the `TEST_LB` environment variable to true:
 
 `make test-container-image` will build the test container image locally.
 
-`make release-test-image` will push a locally built container image to the LR container registry.
+`make release-test-image` will push a locally built container image to the LR
+container registry.
 
 The registry will not allow redefining an existing tag
 so the container version defined in `bin/dkr-config` must be updated before the
 the new container image is built and pushed.
-
 
 ## Running the tests on the preproduction server
 
 The preprod server is not visible on the open internet.  To run tests on it an
 ssh tunnel must be set up and tests directed to the local end of the tunnel.
 
-The scripts `bin/test-preprod` and bin/dkr-test-preprod set up a tunnel, 
+The scripts `bin/test-preprod` and bin/dkr-test-preprod set up a tunnel,
 run the tests and then tear down the tunnel.
 
 See the script for various parameters that can be set as environment variables.

--- a/readme.md
+++ b/readme.md
@@ -21,21 +21,71 @@ Previously the tests were maintained as part of the system operations. In order
 to allow other developers to work on maintaining the tests without being
 committers to the Ops project, these tests now standalone.
 
-## Setup
+## Running the tests
+
+There are two ways to run the tests, either in a docker container or natively.
+
+The docker container provides a stable software environment for running the tests.
+Running natively does not require docker to be installed.
+
+##  Running with Docker
+
+### Setup
+
+- Docker must be installed and the docker daemon running
+- the aws credentials helper should be installed and configured - 
+  see https://github.com/awslabs/amazon-ecr-credential-helper/blob/master/README.md
+  The AWS_PROFILE should be set - defaults to 'lr'
+- to download the container `make install-test-container`
+
+### Running the tests
+
+Standard test configurations can be run using make:
+
+- `make test-dev`
+- `make test-preprod`
+- `make test-production`
+
+Alternatively the test scripts can be run directly, e.g.
+
+```
+    TEST_HOST=lr-ppd-dev-pres-1.epimorphics.net bin/dkr-test
+```
+or
+```
+   TEST_URL=http://lr-ppd-dev-pres-1.epimorphics.net bin/dkr-test
+```
+
+When using docker, the docker image provides only the test environment and software.
+The tests and tests scripts are as defined in the native file system. Any local edits
+to the tests and scripts will be executed by the container.
+
+To get an interactive bash shell in the docker container, e.g. for debugging:
+
+
+```
+    TEST_CMD="bash -" bin/dkr-test
+```
+
+Other environment variables that control the execution of the tests are as described below.
+
+## Running Natively
+
+### Setup
 
 Expected Ruby version is specified in `.ruby-version`. Use [rbenv](https://github.com/rbenv/rbenv)
 to manage local Ruby versions on developer machines.
 
 Run `bundle` in the root directory to install Rubygems dependencies.
 
-## Running the tests
+### Running the tests
 
 Determine which server is going to be tested, e.g. `lr-ppd-dev-pres-1`, then
 
 invoke the tests:
 
-```sh
-TEST_HOST=lr-ppd-dev-pres-1.epimorphics.net bin/test
+```
+    TEST_HOST=lr-ppd-dev-pres.epimorphics.net bin/test
 ```
 
 This runs:
@@ -48,16 +98,55 @@ The service to test can also be a load-balancer, but note that the mod-QoS tests
 do not work in this case. To use a load-balacer as the `TEST_HOST`, set the `TEST_LB`
 environment variable:
 
+
 ```sh
 TEST_LB=1 TEST_HOST=lr-ppd-dev-pres.epimorphics.net bin/test
 ```
+
+## Environment Variables
+
+### Tests dependent on recent data
+
+By default, the tests will omit any tests dependent on there being recent data
+available to test against.  To **include** the recent tests in the test run, set the environment
+variable `RECENT` to any non-empty value:
+
+    RECENT=1 TEST_HOST=lr-ppd-dev-pres.epimorphics.net bin/test
+    
+### Tests that don't work a CI environment
+
+Most tests works in a CI environment, but standard reports tests do not.  To exclude
+these tests:
+
+    IN_CI=1 TEST_HOST=lr-ppd-dev-pres.epimorphics.net bin/test
+
+### Testing via a Load Balancer
+
+Some tests, such as the quality of service tests, do not work via a load balancer.
+To disable these tests set the `TEST_LB` environment variable to true:
+```
+   TEST_LB=true TEST_URL=https://landregistry.data.gov.uk bin/test
+```
+
+## Building the Docker Image
+
+`make test-container-image` will build the test container image locally.
+
+`make release-test-image` will push a locally built container image to the LR container registry.
+
+The registry will not allow redefining an existing tag
+so the container version defined in `bin/dkr-config` must be updated before the
+the new container image is built and pushed.
+
 
 ## Running the tests on the preproduction server
 
 The preprod server is not visible on the open internet.  To run tests on it an
 ssh tunnel must be set up and tests directed to the local end of the tunnel.
 
-The script `bin/test-preprod` sets up a tunnel, runs the tests and then tears down the tunnel.
+The scripts `bin/test-preprod` and bin/dkr-test-preprod set up a tunnel, 
+run the tests and then tear down the tunnel.
+
 See the script for various parameters that can be set as environment variables.
 
 An entry in `/etc/hosts` is needed to map `lr-pres-tunnel.epimorphics.net` to `localhost`.
@@ -72,29 +161,6 @@ This will start an ssh process to implement the tunnel in the background.
 The ssh process must be killed when finished.
 
 Point a browser at `http://lr-pres-tunnel.epimorphics.net:${PORT}`.
-
-## Tests dependent on recent data
-
-By default, the tests will omit any tests dependent on there being recent data
-available to test against. These tests are tagged in the cucumber features with
-`@recent`. To **include** the recent tests in the test run, set the environment
-variable `RECENT` to any non-empty value:
-
-```sh
-RECENT=1 TEST_HOST=lr-ppd-dev-pres.epimorphics.net bin/test
-```
-
-## Tests that don't work in a CI environment
-
-Most tests works in a CI environment, but standard reports tests do not.  To exclude
-these tests:
-
-```sh
-TEST_LB=1 IN_CI=1 TEST_HOST=lr-ppd-dev-pres.epimorphics.net bin/test
-```
-
-This tests the dev server via a load balancer.  To test the server directly use
-`lr-ppd-dev-pres-1`.
 
 ## Full list of test options
 


### PR DESCRIPTION
Running tests in a container - largely as previous version but with latest version of tests merged in.

Abandoned attempt to grant access to the container hosts X display.  Its doable on linux but too messy and unsupported on other platforms.